### PR TITLE
finalize button now disabled if there is no winner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,8 @@ target/
 tmp/
 winner_list*.txt
 
+# VS code
+.vscode
+
 # Created by .ignore support plugin (hsz.mobi)
 

--- a/templates/includes/buttons/finalize.html
+++ b/templates/includes/buttons/finalize.html
@@ -1,3 +1,3 @@
-<a class="btn btn-lg btn-primary" href="finalize" role="button">
+<a class="btn btn-lg btn-primary {% if not winners %}disabled{% endif %}" href="finalize" role="button">
     <i class="fa fa-beer" aria-hidden="true"></i> Finalize
 </a>

--- a/templates/random.html
+++ b/templates/random.html
@@ -29,6 +29,10 @@
             {# <a class="btn-sm btn-danger" href="pass" role="button">Leave slot empty</a>#}
             {# </li>#}
         </ul>
+    {% else %}
+        {% if winners %}
+            {% include "includes/buttons/finalize.html" %}
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block marketing %}


### PR DESCRIPTION
Ho modificato il template di finalize con un if che controlla se la variabile iniettata 'winners'  è  una lista vuota e aggiunge disabled alla classe del bottone come da docs di bootstrap.

Ho aggiunto un altro commit riguardante la issue #29 per non creare un altra PR per una modifica così piccola. 